### PR TITLE
ADD: implement Laravel route visualization using Cytoscape

### DIFF
--- a/media/graphView.js
+++ b/media/graphView.js
@@ -1,0 +1,45 @@
+const cy = cytoscape({
+    container: document.getElementById('cy'),
+    boxSelectionEnabled: false,
+    autounselectify: true,
+    style: [
+        {
+        selector: 'node',
+        style: {
+            'content': 'data(label)',
+            'text-valign': 'center',
+            'color': '#333',
+            'background-color': '#ddd',
+            'shape': 'round-rectangle',
+            'width': 'label',
+            'padding': '10px',
+            'text-wrap': 'wrap',
+            'text-max-width': 120,
+            'font-size': 12,
+            'border-color': '#555',
+            'border-width': 1
+        }
+        },
+    {
+        selector: 'edge',
+        style: {
+            'width': 2,
+            'line-color': '#ccc',
+            'target-arrow-color': '#ccc',
+            'target-arrow-shape': 'triangle',
+            'curve-style': 'bezier'
+        }
+    }
+    ],
+    layout: {
+        name: 'breadthfirst',
+        directed: true,
+        padding: 10
+    }
+});
+
+function loadGraph(data) {
+    cy.elements().remove();
+    cy.add(data);
+    cy.layout({ name: 'breadthfirst', directed: true }).run();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "routemap",
       "version": "0.0.1",
+      "dependencies": {
+        "cytoscape": "^3.32.0"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
@@ -1566,6 +1569,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cytoscape": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.32.0.tgz",
+      "integrity": "sha512-5JHBC9n75kz5851jeklCPmZWcg3hUe6sjqJvyk3+hVqFaKcHwHgxsjeN1yLmggoUc6STbtm9/NQyabQehfjvWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "contributes": {
     "commands": [
       {
-        "command": "routemap.helloWorld",
-        "title": "Hello World"
+        "command": "extension.showRoutes",
+        "title": "Mostrar Rutas Laravel"
       }
     ]
   },
@@ -31,17 +31,20 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.100.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
+    "@types/vscode": "^1.100.0",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
-    "eslint": "^9.25.1",
-    "typescript": "^5.8.3",
-    "ts-loader": "^9.5.2",
-    "webpack": "^5.99.7",
-    "webpack-cli": "^6.0.1",
     "@vscode/test-cli": "^0.0.10",
-    "@vscode/test-electron": "^2.5.2"
+    "@vscode/test-electron": "^2.5.2",
+    "eslint": "^9.25.1",
+    "ts-loader": "^9.5.2",
+    "typescript": "^5.8.3",
+    "webpack": "^5.99.7",
+    "webpack-cli": "^6.0.1"
+  },
+  "dependencies": {
+    "cytoscape": "^3.32.0"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,26 +1,248 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { exec } from 'child_process';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+    let disposable = vscode.commands.registerCommand('extension.showRoutes', () => {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (!workspaceFolders) {
+            vscode.window.showErrorMessage('Abre una carpeta de proyecto Laravel primero');
+            return;
+        }
+        const projectPath = workspaceFolders[0].uri.fsPath;
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "routemap" is now active!');
+        exec('php artisan route:list --json', { cwd: projectPath }, (error, stdout, stderr) => {
+    if (error) {
+        vscode.window.showErrorMessage('Error ejecutando artisan: ' + error.message);
+        return;
+    }
+    if (stderr) {
+        console.error(stderr);
+    }
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	const disposable = vscode.commands.registerCommand('routemap.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from RouteMap!');
-	});
+    try {
+        const routes = JSON.parse(stdout);
 
-	context.subscriptions.push(disposable);
+        const panel = vscode.window.createWebviewPanel(
+            'routeCoverage',
+            'Laravel Routes',
+            vscode.ViewColumn.One,
+            {
+                enableScripts: true,
+                localResourceRoots: [
+                    vscode.Uri.joinPath(context.extensionUri, 'media')
+                ]
+            }
+        );
+
+        const htmlContent = getHtmlForWebview(panel.webview, context, routes);
+        panel.webview.html = htmlContent;
+
+        panel.webview.onDidReceiveMessage(message => {
+            if (message.command === 'ready') {
+                panel.webview.postMessage({
+                    command: 'loadData',
+                    routes: routes
+                });
+            }
+            else if (message.command === 'filterRoutes') {
+                // Aquí puedes implementar filtrado en backend si lo deseas
+                // Por ahora respondemos con todas las rutas
+                panel.webview.postMessage({
+                    command: 'loadData',
+					routes: routes.filter((route: any) => route.uri.includes(message.filter))
+                });
+            }
+        });
+    } catch (e) {
+        vscode.window.showErrorMessage('No se pudo parsear la salida de artisan');
+    }
+});
+    });
+    context.subscriptions.push(disposable);
 }
 
-// This method is called when your extension is deactivated
+function getHtmlForWebview(webview: vscode.Webview, context: vscode.ExtensionContext, routes: any[]): string {
+    const scriptUri = webview.asWebviewUri(
+        vscode.Uri.joinPath(context.extensionUri, 'media', 'graphView.js')
+    );
+    const cytoscapeCdn = 'https://unpkg.com/cytoscape@3.24.0/dist/cytoscape.min.js';
+
+    return `
+    <!DOCTYPE html>
+	<html lang="es">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Laravel Route Graph</title>
+		<style>
+			html, body {
+				margin: 0; padding: 0; height: 100%; width: 100%;
+				background: #f9f9f9;
+				font-family: 'Segoe UI', sans-serif;
+				display: flex;
+				flex-direction: column;
+			}
+			#toolbar {
+				padding: 8px;
+				background: #fff;
+				border-bottom: 1px solid #ccc;
+				display: flex;
+				align-items: center;
+				gap: 8px;
+			}
+			#filterInput {
+				flex-grow: 1;
+				padding: 6px 8px;
+				font-size: 14px;
+				border: 1px solid #ccc;
+				border-radius: 4px;
+			}
+			#cy {
+				flex-grow: 1;
+				width: 100vw;
+				height: 100%;
+				min-height: 400px;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="toolbar">
+			<input type="text" id="filterInput" placeholder="Filtrar rutas por URI..." />
+			<button id="resetFilter">Mostrar todo</button>
+		</div>
+		<div id="cy"></div>
+
+		<script src="https://unpkg.com/cytoscape@3.24.0/dist/cytoscape.min.js" defer></script>
+		<script>
+			const vscode = acquireVsCodeApi();
+			let cy = null;
+			let currentElements = [];
+			let nodePositions = {}; // Para guardar posiciones y usar layout preset
+
+			document.addEventListener('DOMContentLoaded', () => {
+				const filterInput = document.getElementById('filterInput');
+				const resetFilter = document.getElementById('resetFilter');
+
+				filterInput.addEventListener('input', () => {
+					const filterText = filterInput.value.trim();
+					vscode.postMessage({ command: 'filterRoutes', filter: filterText });
+				});
+
+				resetFilter.addEventListener('click', () => {
+					filterInput.value = '';
+					vscode.postMessage({ command: 'filterRoutes', filter: '' });
+				});
+			});
+
+			window.addEventListener('message', event => {
+				const message = event.data;
+				if (message.command === 'loadData') {
+					const data = buildGraphFromRoutes(message.routes);
+					currentElements = data;
+
+					if (cy) {
+						// Guardar posiciones actuales para preset
+						cy.nodes().forEach(node => {
+							nodePositions[node.id()] = node.position();
+						});
+						cy.destroy();
+					}
+
+					loadGraph(currentElements);
+				}
+			});
+
+			vscode.postMessage({ command: 'ready' });
+
+			function buildGraphFromRoutes(routes) {
+				const elements = [];
+
+				routes.forEach((route, i) => {
+					const routeId = 'route_' + i;
+					const ctrlId = routeId + '_ctrl';
+					const midId = routeId + '_mid';
+
+					elements.push({ data: { id: routeId, label: route.method + ' ' + route.uri } });
+
+					if (route.action) {
+						elements.push({ data: { id: ctrlId, label: route.action } });
+						elements.push({ data: { source: routeId, target: ctrlId } });
+					}
+
+					if (route.middleware && route.middleware.length > 0) {
+						route.middleware.forEach((mw, j) => {
+							const mwId = midId + '_m' + j;
+							elements.push({ data: { id: mwId, label: mw } });
+							elements.push({ data: { source: ctrlId, target: mwId } });
+						});
+					}
+				});
+
+				return elements;
+			}
+
+			function loadGraph(elements) {
+				cy = cytoscape({
+					container: document.getElementById('cy'),
+					elements: elements,
+					style: [
+						{
+							selector: 'node',
+							style: {
+								'background-color': '#ffffff',
+								'border-color': '#FF2D20',
+								'border-width': 2,
+								'label': 'data(label)',
+								'color': '#333333',
+								'font-size': '12px',
+								'text-valign': 'center',
+								'text-halign': 'center',
+								'text-wrap': 'wrap',
+								'width': 'label',
+								'height': 'label',
+								'padding': '8px',
+								'shape': 'roundrectangle',
+								'text-max-width': 160,
+								'font-family': 'Segoe UI, sans-serif'
+							}
+						},
+						{
+							selector: 'edge',
+							style: {
+								'width': 1.5,
+								'line-color': '#999999',
+								'target-arrow-color': '#999999',
+								'target-arrow-shape': 'triangle',
+								'curve-style': 'bezier'
+							}
+						}
+					],
+					layout: {
+						name: 'preset',
+						positions: nodePositions,
+						padding: 10
+					}
+				});
+				if (Object.keys(nodePositions).length === 0) {
+					const layout = cy.layout({
+						name: 'breadthfirst',
+						spacingFactor: 0.4,
+						directed: true,
+						padding: 10
+					});
+					layout.run();
+
+					// Guardar posiciones para la próxima vez
+					cy.nodes().forEach(node => {
+						nodePositions[node.id()] = node.position();
+					});
+				}
+			}
+		</script>
+		<script src="${scriptUri}" defer></script>
+	</body>
+	</html>
+    `;
+}
+
 export function deactivate() {}


### PR DESCRIPTION
This pull request introduces a new feature to visualize Laravel routes in a graph format within a VS Code extension. It includes changes to support route filtering, dynamic graph rendering, and improved user interaction. The most important changes are grouped into feature implementation, dependency updates, and command modifications.

### Feature Implementation:
* Added a new command `extension.showRoutes` in `src/extension.ts` that executes `php artisan route:list --json` to fetch Laravel routes and displays them in a webview with interactive filtering and graph visualization.
* Created a dynamic graph visualization using Cytoscape.js in `media/graphView.js` to represent routes, controllers, and middleware with customizable styles and layouts.

### Dependency Updates:
* Updated `package.json` to add `cytoscape` as a dependency and included development dependencies like `@vscode/test-cli` and `@vscode/test-electron`.

### Command Modifications:
* Replaced the existing `routemap.helloWorld` command with `extension.showRoutes` and updated its title to "Mostrar Rutas Laravel" for better alignment with the new functionality.